### PR TITLE
reverse key: swap bytes from outward in instead of going through the …

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -30,8 +30,8 @@ func PrintVersion() {
 }
 
 func ReverseKey(s string) string {
-	b := make([]byte, len(s))
-	var j int = len(s) - 1
+	b := []byte(s)
+	j := len(s) / 2
 	for i := 0; i <= j; i++ {
 		b[j-i] = s[i]
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import "testing"
+
+func TestReverseKey(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected string
+	}{
+		{"", ""},
+		{"a", "a"},
+		{"ab", "ba"},
+		{"abc", "cba"},
+		{"abcd", "dcba"},
+		{"abcde", "edcba"},
+		{"abcdef", "fedcba"},
+		{"abcdefg", "gfedcba"},
+		{"abcdefgh", "hgfedcba"},
+	}
+
+	for _, test := range tests {
+		v := ReverseKey(test.value)
+		if v != test.expected {
+			t.Errorf("got %q; want %q", v, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
…whole string

This speeds up the reversal by swapping the bytes.

Also, using len(s) - 1 - i vs using a var for len(s) was ~10% faster.

Benchmark using a 256 byte key on a single cpu vm:

    BenchmarkReverseKey     5000000               345 ns/op                                                                                      
    BenchmarkReverseNew     5000000               243 ns/op      

I was unable to run the tests on the vm this was written on because it has an old version of mtbl. The changes and test were put in a separate file in an isolated repo to test and all passed.                                                                             
