### PR TITLE
speed up reversekey by swapping from outside in and using len(b)-1 in…

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,10 +3,11 @@ package utils
 import (
 	"bufio"
 	"fmt"
-	"github.com/edmonds/golang-mtbl"
 	"io"
 	"os"
 	"regexp"
+
+	"github.com/edmonds/golang-mtbl"
 )
 
 var Version string = "0.0.1"
@@ -30,10 +31,10 @@ func PrintVersion() {
 }
 
 func ReverseKey(s string) string {
-	b := make([]byte, len(s))
-	var j int = len(s) - 1
+	b := []byte(s)
+	j := len(s) / 2
 	for i := 0; i <= j; i++ {
-		b[j-i] = s[i]
+		b[i], b[len(b)-1-i] = b[len(b)-1-i], b[i]
 	}
 	return string(b)
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import "testing"
+
+func TestReverseKey(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected string
+	}{
+		{"", ""},
+		{"a", "a"},
+		{"ab", "ba"},
+		{"abc", "cba"},
+		{"abcd", "dcba"},
+		{"abcde", "edcba"},
+		{"abcdef", "fedcba"},
+		{"abcdefg", "gfedcba"},
+		{"abcdefgh", "hgfedcba"},
+	}
+
+	for _, test := range tests {
+		v := ReverseKey(test.value)
+		if v != test.expected {
+			t.Errorf("got %q; want %q", v, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
…stead of making an intermediate var

This drops the usage of an intermediate variable to store the len and, instead, inlines the calculation which provides  ~10-20% speed up in my microbenchmark. It also swaps the values from outside in which reduces iterations of the loop by 50%. This results in ~10-15% speed up.

The microbenchmark reversed a 256 byte key and is, hopefully, a reflection of the approximate delta's between the original version and this version. It also is a good exercise of the CPU cache.

    BenchmarkReverseKeyOrig     5000000               345 ns/op                                                                                   
    BenchmarkReverseNew           5000000               243 ns/op                                                                                   

The ReverseKey func could be ~60% faster than the new version by switching from a string to a []byte parm.