### PR TITLE
Handle self referential MX and NS records

### DIFF
--- a/cmd/inetdata-csvrollup/main.go
+++ b/cmd/inetdata-csvrollup/main.go
@@ -146,9 +146,9 @@ func inputParser(c <-chan string, outc chan<- OutputKey) {
 		if ckey != key {
 			if len(cval) != 0 {
 				outc <- OutputKey{Key: ckey, Vals: cval}
-				ckey = key
-				cval = []string{}
 			}
+			ckey = key
+			cval = []string{}
 		}
 
 		// Cleanup common scan artifacts, not comprehensive

--- a/cmd/inetdata-csvrollup/main.go
+++ b/cmd/inetdata-csvrollup/main.go
@@ -153,7 +153,8 @@ func inputParser(c <-chan string, outc chan<- OutputKey) {
 
 		// Cleanup common scan artifacts, not comprehensive
 
-		// Ignore any records where key is empty or identical to the value (except NS or MX)
+		// Ignore any records where key is empty or identical to the value
+		// (with the exception of certain types)
 		if len(val) >= len(key) {
 			parts := strings.SplitN(val, ",", 2)
 			if len(parts) == 2 && !allowedIdentical(parts[0]) {

--- a/cmd/inetdata-csvrollup/main.go
+++ b/cmd/inetdata-csvrollup/main.go
@@ -95,8 +95,10 @@ func mergeAndEmit(c chan OutputKey, o chan string) {
 	wg.Done()
 }
 
-func allowedIdentical(lookup string) bool {
-	switch lookup {
+// allowedIdentical checks to see if the record type is one of the few
+// DNS record types allowed to point to itself (name=value)
+func allowedIdentical(record_type string) bool {
+	switch record_type {
 	case
 		"ns",
 		"r-ns",

--- a/cmd/inetdata-csvrollup/main.go
+++ b/cmd/inetdata-csvrollup/main.go
@@ -138,10 +138,10 @@ func inputParser(c <-chan string, outc chan<- OutputKey) {
 
 		// Cleanup common scan artifacts, not comprehensive
 
-		// Ignore any records where key is empty or identical to the value (except NS)
+		// Ignore any records where key is empty or identical to the value (except NS or MX)
 		if len(val) >= len(key) {
 			parts := strings.SplitN(val, ",", 2)
-			if len(parts) == 2 && parts[0] != "ns" {
+			if len(parts) == 2 && parts[0] != "ns" && parts[0] != "mx" {
 				if len(parts[1]) == 0 || key == parts[1] {
 					continue
 				}

--- a/cmd/inetdata-sonardnsv2-split/main.go
+++ b/cmd/inetdata-sonardnsv2-split/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/hdm/inetdata-parsers"
 	"io"
 	"os"
 	"os/exec"
@@ -13,6 +12,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/hdm/inetdata-parsers"
 )
 
 var output_count int64 = 0
@@ -115,8 +116,8 @@ func inputParser(c chan string, c_names chan string, c_inverse chan string) {
 			continue
 		}
 
-		// Skip any record that refers to itself
-		if rec.Value == rec.Name {
+		// Skip any record that refers to itself (except NS)
+		if rec.Value == rec.Name && rec.Type != "ns" {
 			continue
 		}
 


### PR DESCRIPTION
This PR addresses two issues with records. 

**First problem**
Self referential DNS `mx` records are valid and exist in the wild.  `inetdata-cvsrollup` is filtering thse values but doing so in a way that emits partial data into the output.

 `{"timestamp":"1587687176","name":"006ds4.state.wy.us","type":"mx","value":"10 006ds4.state.wy.us"}` results in `006ds4.state.wy.us,`

This is due to the logic below that would emit the currently crafted key + value pair when a new key arrives. If this happens when `cval` is empty the code emits an incomplete record. In our example above (and in the test data below) the logic in line 144 prevents self referential `mx` records, the code loops, and if the record is the only one for that DNS name then it will emit the partial result.
 
https://github.com/hdm/inetdata-parsers/blob/41f0a5d4ad463a5fc7e812b6e602b36fb9828181/cmd/inetdata-csvrollup/main.go#L124-L149


**Second problem**
Self referential DNS `ns` records are valid and exist in the wild. In code example above you can see that line 144 of `inetdata-csvrollup` makes allowance for them. That being said, the logic in `inetdata-sonardnsv2-split` will prevent this records from ever making it to `inetdata-csvrollup`.

In the current code the following record, found in a Sonar dataset, would be filtered completely.
```json
{"timestamp":"1587706773","name":"api.quotelookup.net","type":"ns","value":"api.quotelookup.net"}
```

https://github.com/hdm/inetdata-parsers/blob/41f0a5d4ad463a5fc7e812b6e602b36fb9828181/cmd/inetdata-sonardnsv2-split/main.go#L118-L121


----------------------

**Test data**
```json
{"timestamp":"1587687176","name":"foo.bar","type":"a","value":"10.10.10.10"}
{"timestamp":"1587687176","name":"006ds4.state.wy.us","type":"mx","value":"10 006ds4.state.wy.us"}
{"timestamp":"1587687176","name":"api.quotelookup.net","type":"ns","value":"api.quotelookup.net"}
{"timestamp":"1587687176","name":"foo.bar","type":"a","value":"11.11.11.11"}
```

**Test command**
```shell
$ cat test-input.json | go run cmd/inetdata-sonardnsv2-split/main.go test-mx
```

**Forward DNS output, current master**
Issues:
- Missing self referential NS record (issue in inetdata-sonardnsv2)
- Invalid entry for `006ds4.state.wy.us` (issue in indetdata-cvsrollup)

```shell
$ pigz -dc ./test-mx-names.gz
006ds4.state.wy.us,
foo.bar,a,10.10.10.10a,11.11.11.11
```

**Inverse DNS output, current master**
Issues:
- Missing self referential NS record (issue in inetdata-sonardnsv2)
- Invalid entry for `006ds4.state.wy.us` (issue in indetdata-cvsrollup)
```shell
$ pigz -dc ./test-mx-names.gz
006ds4.state.wy.us,
10.10.10.10,r-a,foo.bar
11.11.11.11,r-a,foo.bar
```


**Output after change**
```shell
$ pigz -dc ./test-mx-names.gz 
006ds4.state.wy.us,mx,006ds4.state.wy.us
api.quotelookup.net,ns,api.quotelookup.net
foo.bar,a,10.10.10.10a,11.11.11.11

$ pigz -dc ./test-mx-names-inverse.gz 
006ds4.state.wy.us,r-mx,006ds4.state.wy.us
10.10.10.10,r-a,foo.bar
11.11.11.11,r-a,foo.bar
api.quotelookup.net,r-ns,api.quotelookup.net
```